### PR TITLE
Set responseType after xhr.open() to avoid INVALID_STATE_ERR on Android ...

### DIFF
--- a/lib/RAL/Loader.js
+++ b/lib/RAL/Loader.js
@@ -72,10 +72,10 @@ RAL.Loader = (function() {
       // attempt to load the file
       var xhr = new XMLHttpRequest();
 
-      xhr.responseType = type;
       xhr.onerror = callbacks.onError.bind(this, callbackFail);
       xhr.onload = callbacks.onLoad.bind(this, source, callbackSuccess, callbackFail);
       xhr.open('GET', source, true);
+      xhr.responseType = type;
       xhr.send();
 
       // register our interest in the connection


### PR DESCRIPTION
...Browser
