### PR TITLE
passing URLs in correct way; this solves issue #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Since this is a very common use case, we created this library to simplify it. Ju
     var remoteImage, 
         container = document.querySelector('.imageContainer'),
         toLoad = { 'images': [ 
-           'http://myserver.com/image1.png', 
-           'http://myserver.com/image2.png' ] }; // list of image URLs
+            {src: 'http://myserver.com/image1.png'}, 
+            {src: 'http://myserver.com/image2.png'}
+            ]}; // list of image URLs
 
     toLoad.images.forEach(function(imageToLoad) {
           remoteImage = new RAL.RemoteImage(imageToLoad);


### PR DESCRIPTION
Issue #12 is actually not a bug in library code. 

The error happens because usage sample code is wrong. URLs are passed as strings in sample code, but they must be in fact dictionaries with src attribute, as can be seen from line 14 of  https://github.com/GoogleChrome/apps-resource-loader/blob/master/lib/RAL/Image.js

<pre><code>
RAL.RemoteImage = function(options) { 
...
this.src = this.element.dataset.src || options.src; 
</code></pre>

This ways, it works fine. I tested in on my own Chrome App which is not published yet. Images were retrieved from the net and appended to target container w/o issues.
